### PR TITLE
Set bitfield option flags on visit instead of within the node constructor

### DIFF
--- a/sphinxcontrib/bitfield.py
+++ b/sphinxcontrib/bitfield.py
@@ -10,16 +10,22 @@ from shlex import split
 
 
 class bitfield(nodes.General, nodes.Element):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.options = dict(kwargs['options'])
-        self.options['compact'] = 'compact' in self.options
-        self.options['hflip'] = 'hflip' in self.options
-        self.options['vflip'] = 'vflip' in self.options
-        self.options['uneven'] = 'uneven' in self.options
+    pass
+
+
+def set_bitfield_options(node: bitfield):
+    """
+    Set boolean flags based on user-provided options
+    """
+    node.options = node.attributes.get('options', {})
+    node.options['compact'] = 'compact' in node.options
+    node.options['hflip'] = 'hflip' in node.options
+    node.options['vflip'] = 'vflip' in node.options
+    node.options['uneven'] = 'uneven' in node.options
 
 
 def visit_bitfield_html(self, node):
+    set_bitfield_options(node)
     self.body.append(
         jsonml_stringify(
             render(
@@ -38,6 +44,7 @@ def visit_bitfield_latex(self, node):
                              'LateX support:\n'
                              '  pip install sphinxcontrib-bitfield[LaTeX]', e)
 
+    set_bitfield_options(node)
     svg = jsonml_stringify(
         render(
             loads(' '.join(node.rawsource)),


### PR DESCRIPTION
Thanks for making this! Much more convenient than the other methods I attempted for generating similar diagrams. Has worked great for HTML doc generation.

When generating latexpdf (ie: `sphinx-build -M latexpdf ./ ./_build/pdf/` ), I run into the following exception:

```
Exception occurred:
  File "/usr/local/lib/python3.10/dist-packages/sphinxcontrib/bitfield.py", line 44, in visit_bitfield_latex
    **node.options
AttributeError: 'bitfield' object has no attribute 'options'
```

Here's the full traceback:

```log
# Platform:         linux; (Linux-5.15.0-94-generic-x86_64-with-glibc2.35)
# Sphinx version:   7.2.6
# Python version:   3.10.12 (CPython)
# Docutils version: 0.20.1
# Jinja2 version:   3.1.3
# Pygments version: 2.17.2

# Last messages:
#   processing inter-mcucanbusinterfacedescription.tex...
#   index
#   background
#   general_bus_information
#   non_periodic_messages
#   
#   resolving references...
#   done
#   writing...
#   failed

# Loaded extensions:
#   sphinx.ext.mathjax (7.2.6)
#   alabaster (0.7.16)
#   sphinxcontrib.applehelp (1.0.8)
#   sphinxcontrib.devhelp (1.0.6)
#   sphinxcontrib.htmlhelp (2.0.5)
#   sphinxcontrib.serializinghtml (1.1.10)
#   sphinxcontrib.qthelp (1.0.7)
#   sphinx.ext.graphviz (7.2.6)
#   sphinxcontrib.bitfield (unknown version)

# Traceback:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/sphinx/cmd/build.py", line 298, in build_main
    app.build(args.force_all, args.filenames)
  File "/usr/local/lib/python3.10/dist-packages/sphinx/application.py", line 355, in build
    self.builder.build_update()
  File "/usr/local/lib/python3.10/dist-packages/sphinx/builders/__init__.py", line 290, in build_update
    self.build(['__all__'], to_build)
  File "/usr/local/lib/python3.10/dist-packages/sphinx/builders/__init__.py", line 363, in build
    self.write(docnames, list(updated_docnames), method)
  File "/usr/local/lib/python3.10/dist-packages/sphinx/builders/latex/__init__.py", line 318, in write
    docwriter.write(doctree, destination)
  File "/usr/local/lib/python3.10/dist-packages/docutils/writers/__init__.py", line 80, in write
    self.translate()
  File "/usr/local/lib/python3.10/dist-packages/sphinx/writers/latex.py", line 88, in translate
    self.document.walkabout(visitor)
  File "/usr/local/lib/python3.10/dist-packages/docutils/nodes.py", line 186, in walkabout
    if child.walkabout(visitor):
  File "/usr/local/lib/python3.10/dist-packages/docutils/nodes.py", line 186, in walkabout
    if child.walkabout(visitor):
  File "/usr/local/lib/python3.10/dist-packages/docutils/nodes.py", line 186, in walkabout
    if child.walkabout(visitor):
  [Previous line repeated 3 more times]
  File "/usr/local/lib/python3.10/dist-packages/docutils/nodes.py", line 178, in walkabout
    visitor.dispatch_visit(self)
  File "/usr/local/lib/python3.10/dist-packages/sphinx/util/docutils.py", line 582, in dispatch_visit
    method(node)
  File "/usr/local/lib/python3.10/dist-packages/sphinxcontrib/bitfield.py", line 44, in visit_bitfield_latex
    **node.options
AttributeError: 'bitfield' object has no attribute 'options'
```

Curious if you're able to recreate the error?

Here's the relevant page source:

```rst
.. bitfield::
    :bits: 128
    :lanes: 4
    :hflip:
    :vflip:
    :compact:

    [
        { "name": "ID (U32)", "bits": 32},
        { "name": "Message Length (U8)",   "bits": 8},
        { "name": "Reserved/Padding",   "bits": 24, "type": 1},
        { "name": "Data (Array of U8)", "bits": 64 },
        { "bits": 8 }
    ]
```

digging in a little more, it appears that the `self.options` member created within the `bitfield` node constructor is somehow lost by the time `visit_bitfield_latex` is called. I'm not entirely sure as to what the root cause of that is. 


As a quick fix I moved the option flag setting to a separate function that is called during the `visit_bitfield_...` methods