### PR TITLE
Add :caption: option to wrap bitfield directive as a figure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,5 +75,7 @@ The `bitfield` directive accepts the following options:
         trim long bitfield names, must provide the horizontal space available for a single character
     legend:
         space separated list of name and type optionally enclosed in quotes
+    caption:
+        String caption for the bitfield. If specified, the bitfield will be rendered as a figure
 
 For more details, see the `bit_field <https://github.com/Arth-ur/bitfield>`_ package.

--- a/sphinxcontrib/bitfield.py
+++ b/sphinxcontrib/bitfield.py
@@ -1,6 +1,5 @@
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from docutils.parsers.rst.directives import flag
 from bit_field import render, jsonml_stringify
 from json import loads
 from shlex import split
@@ -12,6 +11,14 @@ from sphinx.util.nodes import set_source_info
 def legend(s):
     x = split(s)
     return {k: v for k, v in zip(x[0::2], x[1::2])}
+
+
+def flag_present(argument):
+    """Set option value = True if option was set by user"""
+    if argument and argument.strip():
+        raise ValueError('no argument is allowed; "%s" supplied' % argument)
+    else:
+        return True
 
 
 def figure_wrapper(directive, children, caption) -> nodes.figure:
@@ -38,10 +45,10 @@ class BitfieldDirective(Directive):
         'fontfamily': str,
         'fontweight': str,
         'strokewidth': float,
-        'compact': flag,
-        'hflip': flag,
-        'vflip': flag,
-        'uneven': flag,
+        'compact': flag_present,
+        'hflip': flag_present,
+        'vflip': flag_present,
+        'uneven': flag_present,
         'trim': float,
         'legend': legend,
         'caption': directives.unchanged,

--- a/sphinxcontrib/bitfield.py
+++ b/sphinxcontrib/bitfield.py
@@ -1,16 +1,30 @@
 from docutils import nodes
-from docutils.parsers.rst import Directive
+from docutils.parsers.rst import Directive, directives
 from docutils.parsers.rst.directives import flag
 from bit_field import render, jsonml_stringify
 from json import loads
 from shlex import split
 from base64 import b64encode
 from sphinx import addnodes
+from sphinx.util.nodes import set_source_info
 
 
 def legend(s):
     x = split(s)
     return {k: v for k, v in zip(x[0::2], x[1::2])}
+
+
+def figure_wrapper(directive, children, caption) -> nodes.figure:
+    # based on the figure_wrapper method in sphinx.ext.graphviz
+    # https://github.com/sphinx-doc/sphinx/blob/master/sphinx/ext/graphviz.py
+    figure_node = nodes.figure('', *children)
+
+    inodes, messages = directive.state.inline_text(caption, directive.lineno)
+    caption_node = nodes.caption(caption, '', *inodes)
+    caption_node.extend(messages)
+    set_source_info(directive, caption_node)
+    figure_node += caption_node
+    return figure_node
 
 
 class BitfieldDirective(Directive):
@@ -30,9 +44,14 @@ class BitfieldDirective(Directive):
         'uneven': flag,
         'trim': float,
         'legend': legend,
+        'caption': directives.unchanged,
     }
 
     def run(self):
+        # remove 'caption' since its only used on the sphinx side and bit_field
+        # doesnt recognize it
+        caption = self.options.pop('caption', None)
+
         svg = jsonml_stringify(
             render(
                 loads(' '.join(self.content)),
@@ -45,7 +64,15 @@ class BitfieldDirective(Directive):
         onlynode = addnodes.only(expr='latex')
         onlynode += nodes.image('', uri=uri)
 
-        return [nodes.raw('', svg, format='html'), onlynode]
+        content = [nodes.raw('', svg, format='html'), onlynode]
+
+        if caption is None:
+            return content
+
+        # wrap as a figure
+        fig_node = figure_wrapper(self, content, caption)
+        self.add_name(fig_node)
+        return [fig_node]
 
 
 def setup(app):


### PR DESCRIPTION
This adds a `:caption:` option to `.. bitfield::`. Similar to other diagram directives ( like `.. graphviz::` ) this will wrap the diagram in a 'figure' and can provide extra context to the diagram.

This will need to be rebased/adjusted if #5  is merged first.

Example usage:

```rst
.. bitfield::
    :bits: 16
    :lanes: 1
    :vflip:
    :fontfamily: monospace
    :caption: Heres a test of adding a caption

    [
        { "name": "SIP", "bits": 1},
        { "name": "SC", "bits": 1},
        { "name": "FE", "bits": 1},
        { "name": "WR", "bits": 1},
        { "name": "B", "bits": 1},
        { "name": "NF", "bits": 1},
        { "name": "Reserved", "bits": 10, "type": 1}
    ]
```
results in this (when running `latexpdf` builder) : 
![Screenshot_20240228_103811](https://github.com/Arth-ur/sphinxcontrib-bitfield/assets/15990762/88924d81-5804-45fd-8486-c6ed80537bf6)


Output is identical to current functionality when no caption is specified
